### PR TITLE
Bump up conftest version to 0.18.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM golang:1.13.7-stretch
 
-ENV CONFTEST_VERSION=0.15.0
+ENV CONFTEST_VERSION=0.18.0
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
         ca-certificates \


### PR DESCRIPTION
Bump up to latest version https://github.com/instrumenta/conftest/releases/tag/v0.18.0