### PR TITLE
Do not divide conftest execution into each file

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -24,9 +24,9 @@ match() {
 
 run_conftest() {
   local file
-  local error=false
 
   local -a flags
+  local -a files
 
   if [[ -n ${NAMESPACE} ]]; then
     flags+=(--namespace ${NAMESPACE})
@@ -42,16 +42,14 @@ run_conftest() {
       echo "[DEBUG] ${file}: against the matches condition, so skip it" >&2
       continue
     fi
+    files+=("$file")
 
-    conftest test ${flags[@]} \
-      --no-color \
-      --policy "${POLICY}" \
-      "${file}" || error=true
   done
 
-  if ${error}; then
-    return 1
-  fi
+  conftest test ${flags[@]} \
+    --no-color \
+    --policy "${POLICY}" \
+    "${files[@]}"
 }
 
 main() {


### PR DESCRIPTION
## WHAT

running conftest in loop (on each file) -> running conftest in one time (one execution with all files)

## WHY

To be easier to see logs

Before
![スクリーンショット 2022-03-11 14 33 13](https://user-images.githubusercontent.com/4442708/157808424-6311315a-01d8-488e-86c2-f7a485d65acd.png)

After
![スクリーンショット 2022-03-11 14 32 52](https://user-images.githubusercontent.com/4442708/157808429-8fdd1911-32e4-484c-b2fa-2431ff8ca3f8.png)

